### PR TITLE
[console] add WithMethodName & InjectMultipleTo

### DIFF
--- a/console/console.go
+++ b/console/console.go
@@ -30,17 +30,27 @@ import (
 	"rogchap.com/v8go"
 )
 
+// Console is a single console *method*.
+//
+// This can hardly be called a console, the name is kept for backwords compatability.
 type Console interface {
 	GetLogFunctionCallback() v8go.FunctionCallback
 }
 
-type console struct {
+type consoleMethod struct {
 	Output io.Writer
+	// Method name on the console object, eg. "log", "error"
+	MethodName string
 }
 
+// NewConsole creates a new console method.
+//
+// InjectTo() calls this under the hood, so its best to use that instead
+// if you only want console.log to be available, otherwise use InjectMultipleTo().
 func NewConsole(opt ...Option) Console {
-	c := &console{
-		Output: os.Stdout,
+	c := &consoleMethod{
+		Output:     os.Stdout,
+		MethodName: "log",
 	}
 
 	for _, o := range opt {
@@ -50,7 +60,7 @@ func NewConsole(opt ...Option) Console {
 	return c
 }
 
-func (c *console) GetLogFunctionCallback() v8go.FunctionCallback {
+func (c *consoleMethod) GetLogFunctionCallback() v8go.FunctionCallback {
 	return func(info *v8go.FunctionCallbackInfo) *v8go.Value {
 		if args := info.Args(); len(args) > 0 {
 			inputs := make([]interface{}, len(args))

--- a/console/options.go
+++ b/console/options.go
@@ -27,17 +27,25 @@ import (
 )
 
 type Option interface {
-	apply(c *console)
+	apply(c *consoleMethod)
 }
 
-type optionFunc func(c *console)
+type optionFunc func(c *consoleMethod)
 
-func (f optionFunc) apply(c *console) {
+func (f optionFunc) apply(c *consoleMethod) {
 	f(c)
 }
 
+// WithOutput sets the output for this console method. Default os.Stdout.
 func WithOutput(output io.Writer) Option {
-	return optionFunc(func(c *console) {
+	return optionFunc(func(c *consoleMethod) {
 		c.Output = output
+	})
+}
+
+// WithMethodName sets the method name for this console method. Default "log".
+func WithMethodName(methodName string) Option {
+	return optionFunc(func(c *consoleMethod) {
+		c.MethodName = methodName
 	})
 }


### PR DESCRIPTION
This adds some functions I was missing, I thought I would make a PR.

Seems to work, I get output from both console.error() and console.log():

```go
err := console.InjectMultipleTo(ctx,
	console.NewConsole(console.WithOutput(os.Stderr), console.WithMethodName("error")),
	console.NewConsole(console.WithOutput(os.Stdout), console.WithMethodName("log")),
)
if err != nil {
	return nil, err
}
```