### PR TITLE
take into account ctx.Done() when running timers

### DIFF
--- a/timers/inject.go
+++ b/timers/inject.go
@@ -23,13 +23,14 @@
 package timers
 
 import (
+	"context"
 	"fmt"
 
 	"rogchap.com/v8go"
 )
 
-func InjectTo(iso *v8go.Isolate, global *v8go.ObjectTemplate) error {
-	t := NewTimers()
+func InjectTo(ctx context.Context, iso *v8go.Isolate, global *v8go.ObjectTemplate) error {
+	t := NewTimers(ctx)
 
 	for _, f := range []struct {
 		Name string


### PR DESCRIPTION
When running timers I noticed that when the context gets disposed, the timers are not cancelled, causing nil pointer issues because the timer tries to execute inside a context that does not exist anymore.

This makes sure that the timers get cancelled when the context is marked as done.

## Breaking changes

This PR changes the signature of the timers `InjectTo` function, which breaks current implementations of this function.

## More information

I looking into using the v8go context, but this does not provide the correct information we need to get this to work