### PR TITLE
Add support for compression

### DIFF
--- a/fetch/fetcher.go
+++ b/fetch/fetcher.go
@@ -159,8 +159,9 @@ func (f *fetcher) initRequest(reqUrl string, reqInit internal.RequestInit) (*int
 		URL:  u,
 		Body: reqInit.Body,
 		Header: http.Header{
-			"Accept":     []string{"*/*"},
-			"Connection": []string{"close"},
+			"Accept":          []string{"*/*"},
+			"Accept-Encoding": []string{"gzip, deflate, br"},
+			"Connection":      []string{"close"},
 		},
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,9 @@ module go.kuoruan.net/v8go-polyfills
 
 go 1.16
 
-require rogchap.com/v8go v0.7.0
+require (
+	github.com/andybalholm/brotli v1.0.5
+	rogchap.com/v8go v0.7.0
+)
 
 retract [v0.1.0, v0.3.0]

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
+github.com/andybalholm/brotli v1.0.5 h1:8uQZIdzKmjc/iuPu7O2ioW48L81FgatrcpfFmiq/cCs=
+github.com/andybalholm/brotli v1.0.5/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=
 rogchap.com/v8go v0.7.0 h1:kgjbiO4zE5itA962ze6Hqmbs4HgZbGzmueCXsZtremg=
 rogchap.com/v8go v0.7.0/go.mod h1:MxgP3pL2MW4dpme/72QRs8sgNMmM0pRc8DPhcuLWPAs=


### PR DESCRIPTION
With this PR, compressed responses are automatically and transparently decompressed. Before it was just returning the raw and cryptic payload to the caller.